### PR TITLE
Wrong path for `na-97`

### DIFF
--- a/check_compilation.bat
+++ b/check_compilation.bat
@@ -105,7 +105,7 @@ for %%t in (!issue_ids!) do (
          set "JAVA_FILES=!JAVA_FILES! %%F"
       )
       if "!testcase!"=="na-97" do (
-         set "JAVA_FILES=!JAVA_FILES! --patch-module java.base=src"
+         set "JAVA_FILES=!JAVA_FILES! --patch-module java.base=jdk/src"
       )
       javac -classpath "%SPECIMIN%\src\test\resources\shared\checker-qual-3.42.0.jar" !JAVA_FILES!
       set javac_status=!errorlevel!

--- a/check_compilation.sh
+++ b/check_compilation.sh
@@ -60,7 +60,7 @@ for target in $issue_ids; do
     # javac relies on word splitting
     # shellcheck disable=SC2046
     if [ "$target" = "na-97" ]; then
-      javac -classpath "$SPECIMIN/src/test/resources/shared/checker-qual-3.42.0.jar" $(find . -name "*.java") --patch-module java.base=src
+      javac -classpath "$SPECIMIN/src/test/resources/shared/checker-qual-3.42.0.jar" $(find . -name "*.java") --patch-module java.base=jdk/src
     else
       javac -classpath "$SPECIMIN/src/test/resources/shared/checker-qual-3.42.0.jar" $(find . -name "*.java")
     fi


### PR DESCRIPTION
The compilation scripts pointed to `src/`, not `jdk/src`, where `java.base` should actually be pointing to. Merging this should make njit-jerse/specimin#344 pass.