### PR TITLE
Make na-176 error matching less strict

### DIFF
--- a/resources/test_data.json
+++ b/resources/test_data.json
@@ -694,7 +694,7 @@
             }
         ],
         "bug_pattern": {
-            "error_pattern": "\\s*Stack Trace:\\n(.*)"
+            "error_pattern": "Stack Trace:\\n(.*Exception)"
         },
         "version": "0.4.6",
         "java_version": "",


### PR DESCRIPTION
For njit-jerse/specimin#339; actual and expected outputs slightly differ, so we should account for that (the current setup only matches `java.lang.NullPointerException`)